### PR TITLE
HAS-3 fix(tags): Fix issue with Docker Tagging

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -67,7 +67,7 @@ jobs:
         id: docker-metadata-action
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository }}:latest
+          images: ghcr.io/${{ github.repository }}
           tags: |
             type=ref,event=pr
             type=ref,event=branch


### PR DESCRIPTION
This pull request includes a minor change to the `.github/workflows/java-ci.yml` file. The change removes the `:latest` tag from the `images` property in the `docker-metadata-action` step.

* [`.github/workflows/java-ci.yml`](diffhunk://#diff-30032f912558b3db8571286ce51ce8687b578298bc5e0758ddc8accd7c23dfbbL70-R70): Removed the `:latest` tag from the `images` property in the `docker-metadata-action` step.