### PR TITLE
HAS-3 Setup DEV builds using self contained Dockerfile

### DIFF
--- a/Dockerfile-SelfContained
+++ b/Dockerfile-SelfContained
@@ -1,7 +1,7 @@
 FROM gradle:8.13.0-jdk21-ubi-minimal as builder
 WORKDIR /app
 COPY . .
-RUN gradle build -x test --debug --scan --stacktrace
+RUN gradle build -x test
 
 FROM eclipse-temurin:21.0.6_7-jre-ubi9-minimal
 WORKDIR /app

--- a/Dockerfile-SelfContained
+++ b/Dockerfile-SelfContained
@@ -3,7 +3,7 @@ ENV GITHUB_TOKEN=${GITHUB_PACKAGES_TOKEN}
 ENV GITHUB_ACTOR=${GITHUB_ACTOR}
 WORKDIR /app
 COPY . .
-RUN gradle build -x test
+RUN gradle build -x test --debug --scan --stacktrace
 
 FROM eclipse-temurin:21.0.6_7-jre-ubi9-minimal
 WORKDIR /app

--- a/Dockerfile-SelfContained
+++ b/Dockerfile-SelfContained
@@ -1,6 +1,4 @@
 FROM gradle:8.13.0-jdk21-ubi-minimal as builder
-ENV GITHUB_TOKEN=${GITHUB_PACKAGES_TOKEN}
-ENV GITHUB_ACTOR=${GITHUB_ACTOR}
 WORKDIR /app
 COPY . .
 RUN gradle build -x test --debug --scan --stacktrace

--- a/Dockerfile-SelfContained
+++ b/Dockerfile-SelfContained
@@ -11,3 +11,4 @@ ENV SPRING_PROFILES_ACTIVE=prod
 ENV ARTIFACTORY_PATH=build/libs/*.jar
 COPY --from=builder /app/build/libs/*.jar /app.jar
 CMD ["java", "-jar", "/app.jar"]
+EXPOSE 8080

--- a/Dockerfile-SelfContained
+++ b/Dockerfile-SelfContained
@@ -1,0 +1,13 @@
+FROM gradle:8.13.0-jdk21-ubi-minimal as builder
+ENV GITHUB_TOKEN=${GITHUB_PACKAGES_TOKEN}
+ENV GITHUB_ACTOR=${GITHUB_ACTOR}
+WORKDIR /app
+COPY . .
+RUN gradle build -x test
+
+FROM eclipse-temurin:21.0.6_7-jre-ubi9-minimal
+WORKDIR /app
+ENV SPRING_PROFILES_ACTIVE=prod
+ENV ARTIFACTORY_PATH=build/libs/*.jar
+COPY --from=builder /app/build/libs/*.jar /app.jar
+CMD ["java", "-jar", "/app.jar"]


### PR DESCRIPTION
This pull request introduces a new `Dockerfile-SelfContained` to build and run the application using a multi-stage Docker build process. The key changes include setting up the build environment, copying the application code, building the application, and configuring the runtime environment.

Key changes:

* **Build Environment Setup:**
  * Use `gradle:8.13.0-jdk21-ubi-minimal` as the base image for the build stage.
  * Set the working directory to `/app` and copy the application code into the container.
  * Run the `gradle build -x test` command to build the application, excluding tests.

* **Runtime Environment Setup:**
  * Use `eclipse-temurin:21.0.6_7-jre-ubi9-minimal` as the base image for the runtime stage.
  * Set the working directory to `/app` and configure environment variables for the Spring profile and Artifactory path.
  * Copy the built JAR file from the build stage and set the command to run the application with `java -jar /app.jar`.
  * Expose port 8080 for the application.