### PR TITLE
HAS-3 Dev Docker Builds

### DIFF
--- a/Dockerfile-SelfContained
+++ b/Dockerfile-SelfContained
@@ -1,0 +1,12 @@
+FROM gradle:8.13.0-jdk21-ubi-minimal as builder
+WORKDIR /app
+COPY . .
+RUN gradle build -x test
+
+FROM eclipse-temurin:21.0.6_7-jre-ubi9-minimal
+WORKDIR /app
+ENV SPRING_PROFILES_ACTIVE=prod
+ENV ARTIFACTORY_PATH=build/libs/*.jar
+COPY --from=builder /app/build/libs/*.jar /app.jar
+CMD ["java", "-jar", "/app.jar"]
+EXPOSE 8080


### PR DESCRIPTION
This pull request introduces a new `Dockerfile-SelfContained` to streamline the build and deployment process of the application using a multi-stage Docker build.

Key changes include:

* Added a multi-stage Docker build process to the `Dockerfile-SelfContained` to optimize the build and deployment of the application. The first stage uses the `gradle:8.13.0-jdk21-ubi-minimal` image to build the application, and the second stage uses the `eclipse-temurin:21.0.6_7-jre-ubi9-minimal` image to run the application.
* Configured the application to run with the `prod` Spring profile and exposed port 8080 for the application.