### PR TITLE
HAS-35 Documents for managing Configuration Sets

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ repositories {
 ext {
     set('springCloudVersion', "2024.0.0")
     set('handlebarsVersion', '4.4.0')
-    set('heimdallCommonsVersion','3')
+    set('heimdallCommonsVersion','6')
 }
 
 dependencies {

--- a/src/main/java/com/heimdallauth/server/dao/documents/ConfigurationSetMaster.java
+++ b/src/main/java/com/heimdallauth/server/dao/documents/ConfigurationSetMaster.java
@@ -1,0 +1,27 @@
+package com.heimdallauth.server.dao.documents;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Document(collection = "configuration_set_master")
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class ConfigurationSetMaster {
+    @Id
+    private UUID id;
+    private String configurationSetName;
+    private String configurationSetDescriptoon;
+    @Indexed(unique = false)
+    private UUID tenantId;
+    private Instant createdAt;
+    private Instant updatedAt;
+    private boolean active;
+}

--- a/src/main/java/com/heimdallauth/server/dao/documents/EmailTemplateDocument.java
+++ b/src/main/java/com/heimdallauth/server/dao/documents/EmailTemplateDocument.java
@@ -1,0 +1,26 @@
+package com.heimdallauth.server.dao.documents;
+
+import com.heimdallauth.server.utils.HeimdallMetadata;
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+import java.util.UUID;
+
+@Document(collection = "email_template")
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class EmailTemplateDocument {
+    @Id
+    private UUID id;
+    private UUID configurationSetId;
+    private String templateName;
+    private List<HeimdallMetadata> metadata;
+    private String subject;
+    private String richBodyContent;
+    private String textBodyContent;
+}

--- a/src/main/java/com/heimdallauth/server/dao/documents/SMTPPropertiesDocument.java
+++ b/src/main/java/com/heimdallauth/server/dao/documents/SMTPPropertiesDocument.java
@@ -1,0 +1,27 @@
+package com.heimdallauth.server.dao.documents;
+
+import com.heimdallauth.server.constants.SmtpEncryption;
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.UUID;
+
+@Document
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class SMTPPropertiesDocument {
+    @Id
+    private UUID id;
+    @Indexed
+    private UUID configurationSetId;
+    private String host;
+    private String port;
+    private String username;
+    private String password;
+    private SmtpEncryption encryption;
+}

--- a/src/main/java/com/heimdallauth/server/dao/documents/SuppressionListDocument.java
+++ b/src/main/java/com/heimdallauth/server/dao/documents/SuppressionListDocument.java
@@ -1,0 +1,29 @@
+package com.heimdallauth.server.dao.documents;
+
+import com.heimdallauth.server.bifrost.SuppressionListEntry;
+import com.heimdallauth.server.utils.HeimdallMetadata;
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+@Document(collection = "suppression_list")
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class SuppressionListDocument {
+    @Id
+    private UUID id;
+    @Indexed
+    private UUID configurationSetId;
+    private List<HeimdallMetadata> metadata;
+    private List<SuppressionListEntry> suppressions;
+    private Instant createdOn;
+    private Instant updatedOn;
+}


### PR DESCRIPTION
This pull request introduces several new data models to the `com.heimdallauth.server.dao.documents` package, enhancing the application's ability to manage configurations, email templates, SMTP properties, and suppression lists. The new models utilize Lombok annotations for boilerplate code reduction and are mapped to MongoDB collections.

New data models:

* [`ConfigurationSetMaster`](diffhunk://#diff-10c751c23a128c276937604a0eb50cd974a8b291589c4dda7be7008f4288016bR1-R27): A model representing a configuration set with fields for ID, name, description, tenant ID, creation and update timestamps, and active status.
* [`EmailTemplateDocument`](diffhunk://#diff-5dee355d90ebde53f0c46c3370fb613b8724e94e1d68378813c9722a55a62c80R1-R26): A model for email templates, including fields for ID, configuration set ID, template name, metadata, subject, and body content.
* [`SMTPPropertiesDocument`](diffhunk://#diff-340563a9eb223491fa8bf2bc271e5743916f077edb44bc7fc0c4b32c231f7cb9R1-R27): A model for SMTP properties, containing fields for ID, configuration set ID, host, port, username, password, and encryption type.
* [`SuppressionListDocument`](diffhunk://#diff-9946c7b81811afb30e3bd9b6a4639369c46315bf6e437172d931bf6adc97244bR1-R29): A model for suppression lists, with fields for ID, configuration set ID, metadata, suppression entries, and timestamps for creation and updates.