### PR TITLE
HAS-36 Update to the TenantId to be included in the Configuration Set

### DIFF
--- a/src/main/java/com/heimdallauth/server/dao/ConfigurationSetDataManager.java
+++ b/src/main/java/com/heimdallauth/server/dao/ConfigurationSetDataManager.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 
 public interface ConfigurationSetDataManager {
     boolean isConfigurationSetNameExist(String configurationSetName);
-    void saveConfigurationSet(String configurationSetName, String configurationSetDescription);
+    void saveConfigurationSet(UUID tenantId, String configurationSetName, String configurationSetDescription);
     void updateConfigurationSetTemplate(String configurationSetId, String templateName, List<HeimdallMetadata> metadata, String subject, String richBodyContent, String textBodyContent);
     void updateConfigurationSetSuppressionList(String configurationSetId, String suppressionListEntry, String suppressionListEntryType);
     void updateConfigurationSetSmtpProperties(String configurationSetId, String host, String port, String username, String password, SmtpEncryption encryption);

--- a/src/main/java/com/heimdallauth/server/dao/ConfigurationSetMongoDataManager.java
+++ b/src/main/java/com/heimdallauth/server/dao/ConfigurationSetMongoDataManager.java
@@ -4,12 +4,10 @@ import com.heimdallauth.server.constants.EmailTemplateAction;
 import com.heimdallauth.server.constants.SmtpEncryption;
 import com.heimdallauth.server.dao.documents.ConfigurationSetMaster;
 import com.heimdallauth.server.dao.documents.EmailTemplateDocument;
-import com.heimdallauth.server.dao.documents.SMTPPropertiesDocument;
 import com.heimdallauth.server.dao.documents.SuppressionListDocument;
 import com.heimdallauth.server.models.ConfigurationSetModel;
 import com.heimdallauth.server.utils.HeimdallMetadata;
 import com.heimdallauth.server.utils.MetadataUtils;
-import org.checkerframework.checker.units.qual.A;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
@@ -39,12 +37,13 @@ public class ConfigurationSetMongoDataManager implements ConfigurationSetDataMan
     }
 
     @Override
-    public void saveConfigurationSet(String configurationSetName, String configurationSetDescription) {
+    public void saveConfigurationSet(UUID tenantId,String configurationSetName, String configurationSetDescription) {
         UUID configurationSetId = UUID.randomUUID();
         ConfigurationSetMaster configurationSetMaster = ConfigurationSetMaster.builder()
                 .id(configurationSetId)
+                .tenantId(tenantId)
                 .configurationSetName(configurationSetName)
-                .configurationSetDescriptoon(configurationSetDescription)
+                .configurationSetDescription(configurationSetDescription)
                 .build();
         List<EmailTemplateDocument> emailTemplates = getEmailTemplates(configurationSetId);
         SuppressionListDocument suppressionListDocument = SuppressionListDocument.builder()

--- a/src/main/java/com/heimdallauth/server/dao/documents/ConfigurationSetMaster.java
+++ b/src/main/java/com/heimdallauth/server/dao/documents/ConfigurationSetMaster.java
@@ -20,8 +20,8 @@ public class ConfigurationSetMaster {
     @Id
     private UUID id;
     private String configurationSetName;
-    private String configurationSetDescriptoon;
-    @Indexed(unique = false)
+    private String configurationSetDescription;
+    @Indexed
     private UUID tenantId;
     private Instant createdAt;
     private Instant updatedAt;

--- a/src/main/java/com/heimdallauth/server/services/ConfigurationSetManagementService.java
+++ b/src/main/java/com/heimdallauth/server/services/ConfigurationSetManagementService.java
@@ -34,7 +34,7 @@ public class ConfigurationSetManagementService {
     public ConfigurationSetModel createConfigurationSet(String tenantId, String configurationSetName, String configurationSetDescription) throws HeimdallBifrostBadDataException {
         try{
             validateConfigurationSetName(configurationSetName);
-            this.configurationSetDataManager.saveConfigurationSet(configurationSetName, configurationSetDescription);
+            this.configurationSetDataManager.saveConfigurationSet(UUID.fromString(tenantId), configurationSetName, configurationSetDescription);
             return this.configurationSetDataManager.getConfigurationSetByName(configurationSetName, UUID.fromString(tenantId) );
         }catch (ConfigurationSetAlreadyExists e){
             log.error("Configuration set with the same name already exists: {}", configurationSetName);


### PR DESCRIPTION
This pull request includes several changes to the `ConfigurationSet` management functionality to add tenant support. The most important changes include modifying the `saveConfigurationSet` method to include a `tenantId` parameter, updating the `ConfigurationSetMaster` class to store the `tenantId`, and ensuring that the new parameter is used throughout the relevant methods.

Changes to add tenant support:

* [`src/main/java/com/heimdallauth/server/dao/ConfigurationSetDataManager.java`](diffhunk://#diff-47998e4d353efbe4928b7edc896e50d177ae9e88c2a36e0fae748d5017711e24L12-R12): Modified the `saveConfigurationSet` method to include a `tenantId` parameter.
* [`src/main/java/com/heimdallauth/server/dao/ConfigurationSetMongoDataManager.java`](diffhunk://#diff-e7ead781971f3071448193074212ac44d6ee3cc0cfa18757e8f0f7ca74dd0415L42-R46): Updated the implementation of the `saveConfigurationSet` method to include the `tenantId` parameter and fixed a typo in `configurationSetDescription`.
* [`src/main/java/com/heimdallauth/server/dao/documents/ConfigurationSetMaster.java`](diffhunk://#diff-10c751c23a128c276937604a0eb50cd974a8b291589c4dda7be7008f4288016bL23-R24): Added a `tenantId` field to the `ConfigurationSetMaster` class and removed the typo in `configurationSetDescription`.
* [`src/main/java/com/heimdallauth/server/services/ConfigurationSetManagementService.java`](diffhunk://#diff-f25696d97c6193ba80ffb648f73ee3ab6429b5a88401d9158b763103645164c9L37-R37): Updated the `createConfigurationSet` method to pass the `tenantId` to the `saveConfigurationSet` method.

Minor cleanup:

* [`src/main/java/com/heimdallauth/server/dao/ConfigurationSetMongoDataManager.java`](diffhunk://#diff-e7ead781971f3071448193074212ac44d6ee3cc0cfa18757e8f0f7ca74dd0415L7-L12): Removed unused imports.