### PR TITLE
HAS-37 Updates to the automated test cases

### DIFF
--- a/src/test/java/com/heimdallauth/server/services/ConfigurationSetManagementServiceTest.java
+++ b/src/test/java/com/heimdallauth/server/services/ConfigurationSetManagementServiceTest.java
@@ -1,0 +1,64 @@
+package com.heimdallauth.server.services;
+
+import com.heimdallauth.server.dao.ConfigurationSetDataManager;
+import com.heimdallauth.server.exceptions.HeimdallBifrostBadDataException;
+import com.heimdallauth.server.models.ConfigurationSetModel;
+import com.heimdallauth.server.models.EmailTemplateModel;
+import com.heimdallauth.server.models.SmtpProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConfigurationSetManagementServiceTest {
+    private static final Logger log = LoggerFactory.getLogger(ConfigurationSetManagementServiceTest.class);
+    private ConfigurationSetManagementService configurationSetManagementService;
+
+    private static final String TEST_CONFIGURATION_SET_ID = UUID.randomUUID().toString();
+    private static final String TEST_CONFIGURATION_SET_NAME = "Test Configuration Set";
+    private static final String TEST_CONFIGURATION_SET_DESCRIPTION = "Test Configuration Set Description";
+    private static final List<EmailTemplateModel> TEST_TEMPLATES = List.of();
+    private static final ConfigurationSetModel TEST_CONFIGURATION_SET_MODEL = ConfigurationSetModel.builder()
+            .configurationSetId(TEST_CONFIGURATION_SET_ID)
+            .configurationSetName(TEST_CONFIGURATION_SET_NAME)
+            .configurationSetDescription(TEST_CONFIGURATION_SET_DESCRIPTION)
+            .templates(TEST_TEMPLATES)
+            .smtpProperties(SmtpProperties.builder().build())
+            .build();
+    @Mock
+    private ConfigurationSetDataManager configurationSetDataManager;
+
+    @BeforeEach
+    public void setup(){
+        try{
+            MockitoAnnotations.openMocks(this);
+            this.configurationSetManagementService = new ConfigurationSetManagementService(configurationSetDataManager);
+        }catch (Exception e){
+            log.debug(e.getMessage());
+        }
+    }
+    @Test
+    public void testCreateConfigurationSet_withUniqueConfigurationSetName(){
+        when(configurationSetDataManager.isConfigurationSetNameExist(Mockito.anyString())).thenReturn(Boolean.FALSE);
+        when(configurationSetDataManager.getConfigurationSetByName(Mockito.anyString(), Mockito.any())).thenReturn(TEST_CONFIGURATION_SET_MODEL);
+        configurationSetManagementService.createConfigurationSet(TEST_CONFIGURATION_SET_ID, TEST_CONFIGURATION_SET_NAME, TEST_CONFIGURATION_SET_DESCRIPTION);
+    }
+    @Test
+    public void testCreateConfigurationSet_withNonUniqueConfigurationSetName(){
+        when(configurationSetDataManager.isConfigurationSetNameExist(Mockito.anyString())).thenReturn(Boolean.TRUE);
+        assertThrows(HeimdallBifrostBadDataException.class, () -> configurationSetManagementService.createConfigurationSet(TEST_CONFIGURATION_SET_ID, TEST_CONFIGURATION_SET_NAME, TEST_CONFIGURATION_SET_DESCRIPTION));
+    }
+}

--- a/src/test/java/com/heimdallauth/server/services/ConfigurationSetManagementServiceTest.java
+++ b/src/test/java/com/heimdallauth/server/services/ConfigurationSetManagementServiceTest.java
@@ -54,7 +54,7 @@ public class ConfigurationSetManagementServiceTest {
     public void testCreateConfigurationSet_withUniqueConfigurationSetName(){
         when(configurationSetDataManager.isConfigurationSetNameExist(Mockito.anyString())).thenReturn(Boolean.FALSE);
         when(configurationSetDataManager.getConfigurationSetByName(Mockito.anyString(), Mockito.any())).thenReturn(TEST_CONFIGURATION_SET_MODEL);
-        configurationSetManagementService.createConfigurationSet(TEST_CONFIGURATION_SET_ID, TEST_CONFIGURATION_SET_NAME, TEST_CONFIGURATION_SET_DESCRIPTION);
+        configurationSetManagementService.createConfigurationSet(UUID.randomUUID().toString(), TEST_CONFIGURATION_SET_NAME, TEST_CONFIGURATION_SET_DESCRIPTION);
     }
     @Test
     public void testCreateConfigurationSet_withNonUniqueConfigurationSetName(){


### PR DESCRIPTION
This pull request adds a new test class for the `ConfigurationSetManagementService` to ensure the correct handling of configuration sets, including scenarios with unique and non-unique names. The most important changes include the addition of the test class, setup methods, and specific test cases for the service.

New test class and setup:

* [`src/test/java/com/heimdallauth/server/services/ConfigurationSetManagementServiceTest.java`](diffhunk://#diff-aa22cd4203ae274b44772ffe5dd922811051590936efacf629bb1e6cfc75a21fR1-R64): Added a new test class `ConfigurationSetManagementServiceTest` with setup methods and mock dependencies to test the `ConfigurationSetManagementService`.

Test cases for configuration set creation:

* [`src/test/java/com/heimdallauth/server/services/ConfigurationSetManagementServiceTest.java`](diffhunk://#diff-aa22cd4203ae274b44772ffe5dd922811051590936efacf629bb1e6cfc75a21fR1-R64): Added `testCreateConfigurationSet_withUniqueConfigurationSetName` to verify the creation of a configuration set with a unique name.
* [`src/test/java/com/heimdallauth/server/services/ConfigurationSetManagementServiceTest.java`](diffhunk://#diff-aa22cd4203ae274b44772ffe5dd922811051590936efacf629bb1e6cfc75a21fR1-R64): Added `testCreateConfigurationSet_withNonUniqueConfigurationSetName` to ensure an exception is thrown when attempting to create a configuration set with a non-unique name.