### PR TITLE
HAS-38 Update to the CI for testing step

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -15,6 +15,29 @@ permissions:
   packages: write
   pull-requests: write
 jobs:
+  unit-testing:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Setup JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'adopt'
+          java-version: '21'
+      - name: Cache Gradle Packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: Build with Gradle
+        run: ./gradlew test
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ github.ref_type == 'tag' && github.ref_name || github.run_number }}
   java-ci:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This pull request includes the addition of a new job for unit testing in the GitHub Actions workflow for Java CI. The most important changes are the addition of steps to set up the environment, cache dependencies, and run tests.

New unit testing job:

* [`.github/workflows/java-ci.yml`](diffhunk://#diff-30032f912558b3db8571286ce51ce8687b578298bc5e0758ddc8accd7c23dfbbR18-R40): Added a `unit-testing` job that runs on `ubuntu-latest`, checks out the repository, sets up JDK 21, caches Gradle packages, and builds with Gradle.