### PR TITLE
HAS-39 Create ConfigurationSet API endpoints

### DIFF
--- a/Dockerfile-SelfContained
+++ b/Dockerfile-SelfContained
@@ -6,6 +6,7 @@ RUN gradle build -x test
 FROM eclipse-temurin:21.0.6_7-jre-ubi9-minimal
 WORKDIR /app
 ENV SPRING_PROFILES_ACTIVE=prod
+ENV PUBLIC_FQDN=$COOLIFY_FQDN
 ENV ARTIFACTORY_PATH=build/libs/*.jar
 COPY --from=builder /app/build/libs/*.jar /app.jar
 CMD ["java", "-jar", "/app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ repositories {
 ext {
     set('springCloudVersion', "2024.0.0")
     set('handlebarsVersion', '4.4.0')
-    set('heimdallCommonsVersion','24')
+    set('heimdallCommonsVersion','25')
     set('mapStructVersion', '1.6.3')
 }
 

--- a/src/main/java/com/heimdallauth/server/controllers/v1/management/ConfigurationSetManagementController.java
+++ b/src/main/java/com/heimdallauth/server/controllers/v1/management/ConfigurationSetManagementController.java
@@ -1,0 +1,36 @@
+package com.heimdallauth.server.controllers.v1.management;
+
+import com.heimdallauth.server.dto.bifrost.CreateConfigurationSetDTO;
+import com.heimdallauth.server.models.bifrost.ConfigurationSetModel;
+import com.heimdallauth.server.services.ConfigurationSetManagementService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/v1/management/configuration-set")
+@Tag(name = "Configuration Set Management Controller", description = "Controller for managing configuration sets")
+public class ConfigurationSetManagementController {
+    private final ConfigurationSetManagementService configurationSetManagementService;
+
+    public ConfigurationSetManagementController(ConfigurationSetManagementService configurationSetManagementService) {
+        this.configurationSetManagementService = configurationSetManagementService;
+    }
+    @GetMapping("/{configurationSetId}")
+    public ResponseEntity<ConfigurationSetModel> getConfigurationSet(@PathVariable UUID configurationSetId) {
+        return ResponseEntity.ok(this.configurationSetManagementService.getConfigurationSetById(configurationSetId));
+    }
+    @PostMapping("/create")
+    public ResponseEntity<ConfigurationSetModel> createNewConfigurationSet(@RequestBody CreateConfigurationSetDTO createConfigurationSetDTO, @RequestParam("force") boolean force){
+        ConfigurationSetModel createdConfigurationSet = this.configurationSetManagementService.createNewConfigurationSet(createConfigurationSetDTO, UUID.randomUUID(), force);
+        return ResponseEntity.created(ServletUriComponentsBuilder.fromCurrentRequest().path("/{id}").buildAndExpand(createdConfigurationSet.getConfigurationSetId()).toUri()).build();
+    }
+    @GetMapping
+    public ResponseEntity<List<ConfigurationSetModel>> getConfigurationSetForTenantId(@RequestParam("tenantId") UUID tenantId){
+        return ResponseEntity.ok(this.configurationSetManagementService.getConfigurationSetsForTenantId(tenantId));
+    }
+}

--- a/src/main/java/com/heimdallauth/server/documents/ConfigurationSetMasterDocument.java
+++ b/src/main/java/com/heimdallauth/server/documents/ConfigurationSetMasterDocument.java
@@ -18,7 +18,7 @@ import java.util.UUID;
 @Setter
 public class ConfigurationSetMasterDocument {
     @Id
-    private UUID configurationId;
+    private String configurationId;
     private String configurationSetName;
     private String configurationSetDescription;
     @Indexed

--- a/src/main/java/com/heimdallauth/server/services/ConfigurationSetManagementService.java
+++ b/src/main/java/com/heimdallauth/server/services/ConfigurationSetManagementService.java
@@ -6,11 +6,13 @@ import com.heimdallauth.server.exceptions.ConfigurationSetAlreadyExists;
 import com.heimdallauth.server.exceptions.ConfigurationSetNotFound;
 import com.heimdallauth.server.models.bifrost.ConfigurationSetModel;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface ConfigurationSetManagementService {
     ConfigurationSetModel createNewConfigurationSet(CreateConfigurationSetDTO createConfigurationSetPayload, UUID tenantID, boolean force) throws ConfigurationSetAlreadyExists;
     ConfigurationSetModel getConfigurationSetById(UUID configurationSetId) throws ConfigurationSetNotFound;
+    List<ConfigurationSetModel> getConfigurationSetsForTenantId(UUID tenantId);
     ConfigurationSetModel getConfigurationSetByNameAndTenantId(String configurationSetName, String tenantId) throws ConfigurationSetNotFound;
     ConfigurationSetModel updateConfigurationSetMasterData(String configurationSetId, String configurationSetName, String configurationSetDescription) throws ConfigurationSetNotFound;
 }

--- a/src/main/java/com/heimdallauth/server/services/mongo/ConfigurationServiceManagementServiceMongoImpl.java
+++ b/src/main/java/com/heimdallauth/server/services/mongo/ConfigurationServiceManagementServiceMongoImpl.java
@@ -71,7 +71,7 @@ public class ConfigurationServiceManagementServiceMongoImpl implements Configura
         }
         UUID configurationSetId = UUID.randomUUID();
         ConfigurationSetMasterDocument configurationSetMasterDocument = ConfigurationSetMasterDocument.builder()
-                .configurationId(configurationSetId)
+                .configurationId(configurationSetId.toString())
                 .tenantId(tenantId)
                 .configurationSetName(createConfigurationSetPayload.getConfigurationSetName())
                 .configurationSetDescription(createConfigurationSetPayload.getConfigurationSetDescription())

--- a/src/main/java/com/heimdallauth/server/utils/mapper/ConfigurationMapper.java
+++ b/src/main/java/com/heimdallauth/server/utils/mapper/ConfigurationMapper.java
@@ -1,13 +1,14 @@
 package com.heimdallauth.server.utils.mapper;
 
 import com.heimdallauth.server.documents.ConfigurationSetAggregationModel;
+import com.heimdallauth.server.documents.ConfigurationSetMasterDocument;
 import com.heimdallauth.server.models.bifrost.ConfigurationSetModel;
 import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
 import org.mapstruct.MappingConstants;
 
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
 public interface ConfigurationMapper {
 
     ConfigurationSetModel toConfigurationSetModel(ConfigurationSetAggregationModel aggregationModel);
+    ConfigurationSetModel toConfigurationSetModel(ConfigurationSetMasterDocument masterDocument);
 }

--- a/src/main/resources/application-develop.yml
+++ b/src/main/resources/application-develop.yml
@@ -4,6 +4,7 @@ spring:
       discovery:
         enabled: true
         health-check-path: /actuator/health
+        hostname: ${PUBLIC_FQDN}
         health-check-interval: 15s
         health-check-timeout: 10s
       host: ${CONSUL_FQDN}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,3 @@
 spring.application.name=bifrost
-spring.data.mongodb.auto-index-creation=true
+#spring.data.mongodb.auto-index-creation=true
 server.forward-headers-strategy=framework


### PR DESCRIPTION
This pull request includes several changes aimed at enhancing the configuration management functionality and improving the system's overall efficiency. The most important changes include the addition of a new controller for managing configuration sets, updates to existing services and documents, and configuration adjustments.

### Enhancements to Configuration Management:

* **New Controller for Configuration Sets**:
  - Added `ConfigurationSetManagementController` to manage configuration sets, including endpoints for creating, retrieving, and listing configuration sets.

* **Service Updates**:
  - Updated `ConfigurationSetManagementService` interface to include a method for retrieving configuration sets by tenant ID.
  - Implemented the new method in `ConfigurationServiceManagementServiceMongoImpl` to query configuration sets by tenant ID.

* **Document Updates**:
  - Changed the type of `configurationId` from `UUID` to `String` in `ConfigurationSetMasterDocument`.

### Configuration Adjustments:

* **Dockerfile Update**:
  - Added `PUBLIC_FQDN` environment variable to `Dockerfile-SelfContained`.

* **Application Configuration**:
  - Added `hostname` configuration in `application-develop.yml` to use `PUBLIC_FQDN`.
  - Commented out `spring.data.mongodb.auto-index-creation` property in `application.properties`.

These changes collectively improve the system's ability to manage configuration sets, enhance its scalability, and ensure better configuration management.