### PR TITLE
HAS-39 Various Fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ repositories {
 ext {
     set('springCloudVersion', "2024.0.0")
     set('handlebarsVersion', '4.4.0')
-    set('heimdallCommonsVersion','25')
+    set('heimdallCommonsVersion','27')
     set('mapStructVersion', '1.6.3')
 }
 

--- a/src/main/java/com/heimdallauth/server/controllers/v1/management/ConfigurationSetManagementController.java
+++ b/src/main/java/com/heimdallauth/server/controllers/v1/management/ConfigurationSetManagementController.java
@@ -27,7 +27,7 @@ public class ConfigurationSetManagementController {
     @PostMapping("/create")
     public ResponseEntity<ConfigurationSetModel> createNewConfigurationSet(@RequestBody CreateConfigurationSetDTO createConfigurationSetDTO, @RequestParam("force") boolean force){
         ConfigurationSetModel createdConfigurationSet = this.configurationSetManagementService.createNewConfigurationSet(createConfigurationSetDTO, UUID.randomUUID(), force);
-        return ResponseEntity.created(ServletUriComponentsBuilder.fromCurrentRequest().path("/{id}").buildAndExpand(createdConfigurationSet.getConfigurationSetId()).toUri()).build();
+        return ResponseEntity.created(ServletUriComponentsBuilder.fromCurrentRequest().path("/{id}").buildAndExpand(createdConfigurationSet.configurationSetId()).toUri()).build();
     }
     @GetMapping
     public ResponseEntity<List<ConfigurationSetModel>> getConfigurationSetForTenantId(@RequestParam("tenantId") UUID tenantId){

--- a/src/main/java/com/heimdallauth/server/controllers/v1/management/ConfigurationSetManagementController.java
+++ b/src/main/java/com/heimdallauth/server/controllers/v1/management/ConfigurationSetManagementController.java
@@ -26,7 +26,7 @@ public class ConfigurationSetManagementController {
     }
     @PostMapping("/create")
     public ResponseEntity<ConfigurationSetModel> createNewConfigurationSet(@RequestBody CreateConfigurationSetDTO createConfigurationSetDTO, @RequestParam("force") boolean force){
-        ConfigurationSetModel createdConfigurationSet = this.configurationSetManagementService.createNewConfigurationSet(createConfigurationSetDTO, UUID.randomUUID(), force);
+        ConfigurationSetModel createdConfigurationSet = this.configurationSetManagementService.createNewConfigurationSet(createConfigurationSetDTO, createConfigurationSetDTO.tenantId(), force);
         return ResponseEntity.created(ServletUriComponentsBuilder.fromCurrentRequest().path("/{id}").buildAndExpand(createdConfigurationSet.configurationSetId()).toUri()).build();
     }
     @GetMapping

--- a/src/main/java/com/heimdallauth/server/controllers/v1/management/SuppressionEntryManagementController.java
+++ b/src/main/java/com/heimdallauth/server/controllers/v1/management/SuppressionEntryManagementController.java
@@ -35,7 +35,7 @@ public class SuppressionEntryManagementController {
     @PostMapping
     public ResponseEntity<SuppressionEntryModel> createNewSuppressionEntry(@RequestBody CreateSuppressionEntryDTO createSuppressionEntryDTO) throws SuppressionListNotFound {
         SuppressionEntryModel createdSuppressionEntry = this.emailSuppressionManagementService.createSuppressionEntry(createSuppressionEntryDTO);
-        return ResponseEntity.created(ServletUriComponentsBuilder.fromCurrentRequest().path("/{id}").buildAndExpand(createdSuppressionEntry.getSuppressionEntryId()).toUri()).build();
+        return ResponseEntity.created(ServletUriComponentsBuilder.fromCurrentRequest().path("/{id}").buildAndExpand(createdSuppressionEntry.suppressionEntryId()).toUri()).build();
     }
     @DeleteMapping("/{suppressionEntryId}")
     public ResponseEntity<Void> deleteSuppressionEntryById(@PathVariable UUID suppressionEntryId) throws SuppressionListNotFound {

--- a/src/main/java/com/heimdallauth/server/documents/ConfigurationSetMasterDocument.java
+++ b/src/main/java/com/heimdallauth/server/documents/ConfigurationSetMasterDocument.java
@@ -24,7 +24,7 @@ public class ConfigurationSetMasterDocument {
     @Indexed
     private UUID tenantId;
     @Indexed
-    private List<UUID> suppressionListIds;
+    private List<String> suppressionListIds;
     private Instant createdAt;
     private Instant updatedAt;
 }

--- a/src/main/java/com/heimdallauth/server/services/ConfigurationSetManagementService.java
+++ b/src/main/java/com/heimdallauth/server/services/ConfigurationSetManagementService.java
@@ -1,6 +1,5 @@
 package com.heimdallauth.server.services;
 
-import com.heimdallauth.server.dto.bifrost.ConfigurationSetDTO;
 import com.heimdallauth.server.dto.bifrost.CreateConfigurationSetDTO;
 import com.heimdallauth.server.exceptions.ConfigurationSetAlreadyExists;
 import com.heimdallauth.server.exceptions.ConfigurationSetNotFound;

--- a/src/main/java/com/heimdallauth/server/services/mongo/ConfigurationServiceManagementServiceMongoImpl.java
+++ b/src/main/java/com/heimdallauth/server/services/mongo/ConfigurationServiceManagementServiceMongoImpl.java
@@ -214,9 +214,9 @@ public class ConfigurationServiceManagementServiceMongoImpl implements Configura
     public SuppressionEntryModel createSuppressionEntry(CreateSuppressionEntryDTO createSuppressionEntryPayload) {
         SuppressionEntryDocument suppressionEntryDocument = SuppressionEntryDocument.builder()
                 .id(UUID.randomUUID().toString())
-                .entryType(createSuppressionEntryPayload.getEntryType())
-                .value(createSuppressionEntryPayload.getSuppressionEntryValue())
-                .reason(createSuppressionEntryPayload.getReason())
+                .entryType(createSuppressionEntryPayload.entryType())
+                .value(createSuppressionEntryPayload.value())
+                .reason(createSuppressionEntryPayload.reason())
                 .createdAt(Instant.now())
                 .updatedAt(Instant.now())
                 .build();
@@ -292,7 +292,7 @@ public class ConfigurationServiceManagementServiceMongoImpl implements Configura
      * @return A list of UUIDs representing the suppression IDs that are not present in the database.
      */
     private List<UUID> getSuppressionIdsNotPresent(List<UUID> idsToValidate){
-        List<UUID> idsMatchedInDB = this.getAllSuppressionEntriesById(idsToValidate).stream().map(SuppressionEntryModel::getSuppressionEntryId).toList();
+        List<UUID> idsMatchedInDB = this.getAllSuppressionEntriesById(idsToValidate).stream().map(SuppressionEntryModel::suppressionEntryId).toList();
         return idsToValidate.stream().filter(id -> !idsMatchedInDB.contains(id)).toList();
     }
     /**

--- a/src/main/java/com/heimdallauth/server/services/mongo/ConfigurationServiceManagementServiceMongoImpl.java
+++ b/src/main/java/com/heimdallauth/server/services/mongo/ConfigurationServiceManagementServiceMongoImpl.java
@@ -117,7 +117,7 @@ public class ConfigurationServiceManagementServiceMongoImpl implements Configura
         if(configurationSetDocuments.isEmpty()){
             return List.of();
         }else{
-            return configurationSetDocuments.stream().map(s -> configurationMapper.toConfigurationSetModel(s)).toList();
+            return configurationSetDocuments.stream().map(configurationMapper::toConfigurationSetModel).toList();
         }
     }
 

--- a/src/main/java/com/heimdallauth/server/services/mongo/ConfigurationServiceManagementServiceMongoImpl.java
+++ b/src/main/java/com/heimdallauth/server/services/mongo/ConfigurationServiceManagementServiceMongoImpl.java
@@ -41,7 +41,6 @@ public class ConfigurationServiceManagementServiceMongoImpl implements Configura
     private final SuppressionEntryMapper suppressionEntryMapper;
     private static final String COLLECTION_CONFIGURATION_SETS = "configuration_sets";
     private static final String COLLECTION_SUPPRESSION_LIST = "suppression_list";
-    private static final String CONFIGURATION_SET_SUPPRESSION_LIST_MAPPING = "configuration_set_suppression_list_mapping";
 
     public ConfigurationServiceManagementServiceMongoImpl(MongoTemplate mongoTemplate, ConfigurationMapper configurationMapper, SuppressionEntryMapper suppressionEntryMapper) {
         this.mongoTemplate = mongoTemplate;

--- a/src/main/java/com/heimdallauth/server/utils/mapper/ConfigurationMapper.java
+++ b/src/main/java/com/heimdallauth/server/utils/mapper/ConfigurationMapper.java
@@ -4,11 +4,13 @@ import com.heimdallauth.server.documents.ConfigurationSetAggregationModel;
 import com.heimdallauth.server.documents.ConfigurationSetMasterDocument;
 import com.heimdallauth.server.models.bifrost.ConfigurationSetModel;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.MappingConstants;
 
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
 public interface ConfigurationMapper {
 
+    @Mapping(source = "configurationId", target = "configurationSetId")
     ConfigurationSetModel toConfigurationSetModel(ConfigurationSetAggregationModel aggregationModel);
     ConfigurationSetModel toConfigurationSetModel(ConfigurationSetMasterDocument masterDocument);
 }


### PR DESCRIPTION
This pull request includes several changes to improve the handling of suppression list IDs and streamline the mapping and creation processes within the `ConfigurationSetManagementService` and related classes. The most important changes include updating the data types for suppression list IDs, modifying method calls to use the updated data types, and refining the mapping configurations.

### Improvements to suppression list ID handling:

* [`src/main/java/com/heimdallauth/server/documents/ConfigurationSetMasterDocument.java`](diffhunk://#diff-0ac1447f3c6bc029976843bccd4a8b2ca1bb7884326a2cfe900433900dc40c0eL27-R27): Changed the type of `suppressionListIds` from `List<UUID>` to `List<String>`.
* [`src/main/java/com/heimdallauth/server/services/mongo/ConfigurationServiceManagementServiceMongoImpl.java`](diffhunk://#diff-bcd03111769d7a27d1cd1b8d009049a1b0a3fe050e9f4cc10854e6e80295604bL78-R77): Updated various methods to handle `suppressionListIds` as `List<String>` instead of `List<UUID>`. [[1]](diffhunk://#diff-bcd03111769d7a27d1cd1b8d009049a1b0a3fe050e9f4cc10854e6e80295604bL78-R77) [[2]](diffhunk://#diff-bcd03111769d7a27d1cd1b8d009049a1b0a3fe050e9f4cc10854e6e80295604bL218-R219) [[3]](diffhunk://#diff-bcd03111769d7a27d1cd1b8d009049a1b0a3fe050e9f4cc10854e6e80295604bL274-R273) [[4]](diffhunk://#diff-bcd03111769d7a27d1cd1b8d009049a1b0a3fe050e9f4cc10854e6e80295604bL312-R313)

### Refinements to method calls and mappings:

* [`src/main/java/com/heimdallauth/server/controllers/v1/management/ConfigurationSetManagementController.java`](diffhunk://#diff-fc569c26f68093b98d702d39090f4ee1b893025d9d50e3cbe18f1ca1dd1eb885L29-R30): Updated the `createNewConfigurationSet` method to use `createConfigurationSetDTO.tenantId()` instead of generating a new UUID.
* [`src/main/java/com/heimdallauth/server/controllers/v1/management/SuppressionEntryManagementController.java`](diffhunk://#diff-596b4c3c318ea63cdc9392c36c34d65746dd2f6d4c29cc31cd0156b8299e6b02L38-R38): Modified the `createNewSuppressionEntry` method to use the updated getter methods for `SuppressionEntryModel`.
* [`src/main/java/com/heimdallauth/server/utils/mapper/ConfigurationMapper.java`](diffhunk://#diff-02e9f71e7d1fa23de6ce43c746ae36016342eca05eb944432dc8be2c0d5919bdR7-R13): Added a mapping configuration to map `configurationId` to `configurationSetId` in `ConfigurationSetModel`.

### Codebase simplification:

* [`src/main/java/com/heimdallauth/server/services/ConfigurationSetManagementService.java`](diffhunk://#diff-f25696d97c6193ba80ffb648f73ee3ab6429b5a88401d9158b763103645164c9L3): Removed an unused import statement for `ConfigurationSetDTO`.
* [`src/main/java/com/heimdallauth/server/services/mongo/ConfigurationServiceManagementServiceMongoImpl.java`](diffhunk://#diff-bcd03111769d7a27d1cd1b8d009049a1b0a3fe050e9f4cc10854e6e80295604bL120-R119): Simplified method references and removed an unused constant. [[1]](diffhunk://#diff-bcd03111769d7a27d1cd1b8d009049a1b0a3fe050e9f4cc10854e6e80295604bL120-R119) [[2]](diffhunk://#diff-bcd03111769d7a27d1cd1b8d009049a1b0a3fe050e9f4cc10854e6e80295604bL133-R133) [[3]](diffhunk://#diff-bcd03111769d7a27d1cd1b8d009049a1b0a3fe050e9f4cc10854e6e80295604bL44)