### PR TITLE
HAS-39 Implement API Security - Configuration Set Management Endpoints

### DIFF
--- a/src/main/java/com/heimdallauth/server/controllers/v1/management/ConfigurationSetManagementController.java
+++ b/src/main/java/com/heimdallauth/server/controllers/v1/management/ConfigurationSetManagementController.java
@@ -27,7 +27,7 @@ public class ConfigurationSetManagementController {
         return ResponseEntity.ok(this.configurationSetManagementService.getConfigurationSetById(configurationSetId));
     }
     @PostMapping("/create")
-    @PreAuthorize("hasRole(@heimdallBifrostRoleConfiguration.ROLE_MANAGEMENT_READ) or hasRole(@heimdallBifrostRoleConfiguration.ROLE_MANAGEMENT_WRITE)")
+    @PreAuthorize("hasRole(@heimdallBifrostRoleConfiguration.ROLE_MANAGEMENT_WRITE)")
     public ResponseEntity<ConfigurationSetModel> createNewConfigurationSet(@RequestBody CreateConfigurationSetDTO createConfigurationSetDTO, @RequestParam("force") boolean force){
         ConfigurationSetModel createdConfigurationSet = this.configurationSetManagementService.createNewConfigurationSet(createConfigurationSetDTO, createConfigurationSetDTO.tenantId(), force);
         return ResponseEntity.created(ServletUriComponentsBuilder.fromCurrentRequest().path("/{id}").buildAndExpand(createdConfigurationSet.configurationSetId()).toUri()).build();

--- a/src/main/java/com/heimdallauth/server/controllers/v1/management/ConfigurationSetManagementController.java
+++ b/src/main/java/com/heimdallauth/server/controllers/v1/management/ConfigurationSetManagementController.java
@@ -5,6 +5,7 @@ import com.heimdallauth.server.models.bifrost.ConfigurationSetModel;
 import com.heimdallauth.server.services.ConfigurationSetManagementService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
@@ -21,15 +22,18 @@ public class ConfigurationSetManagementController {
         this.configurationSetManagementService = configurationSetManagementService;
     }
     @GetMapping("/{configurationSetId}")
+    @PreAuthorize("hasRole(@heimdallBifrostRoleConfiguration.ROLE_MANAGEMENT_READ) or hasRole(@heimdallBifrostRoleConfiguration.ROLE_MANAGEMENT_WRITE)")
     public ResponseEntity<ConfigurationSetModel> getConfigurationSet(@PathVariable UUID configurationSetId) {
         return ResponseEntity.ok(this.configurationSetManagementService.getConfigurationSetById(configurationSetId));
     }
     @PostMapping("/create")
+    @PreAuthorize("hasRole(@heimdallBifrostRoleConfiguration.ROLE_MANAGEMENT_READ) or hasRole(@heimdallBifrostRoleConfiguration.ROLE_MANAGEMENT_WRITE)")
     public ResponseEntity<ConfigurationSetModel> createNewConfigurationSet(@RequestBody CreateConfigurationSetDTO createConfigurationSetDTO, @RequestParam("force") boolean force){
         ConfigurationSetModel createdConfigurationSet = this.configurationSetManagementService.createNewConfigurationSet(createConfigurationSetDTO, createConfigurationSetDTO.tenantId(), force);
         return ResponseEntity.created(ServletUriComponentsBuilder.fromCurrentRequest().path("/{id}").buildAndExpand(createdConfigurationSet.configurationSetId()).toUri()).build();
     }
     @GetMapping
+    @PreAuthorize("hasRole(@heimdallBifrostRoleConfiguration.ROLE_MANAGEMENT_READ) or hasRole(@heimdallBifrostRoleConfiguration.ROLE_MANAGEMENT_WRITE)")
     public ResponseEntity<List<ConfigurationSetModel>> getConfigurationSetForTenantId(@RequestParam("tenantId") UUID tenantId){
         return ResponseEntity.ok(this.configurationSetManagementService.getConfigurationSetsForTenantId(tenantId));
     }


### PR DESCRIPTION
This pull request includes changes to the `ConfigurationSetManagementController` to enhance security by adding role-based access control using the `@PreAuthorize` annotation.

Security enhancements:

* [`src/main/java/com/heimdallauth/server/controllers/v1/management/ConfigurationSetManagementController.java`](diffhunk://#diff-fc569c26f68093b98d702d39090f4ee1b893025d9d50e3cbe18f1ca1dd1eb885R8): Imported `org.springframework.security.access.prepost.PreAuthorize` to enable role-based access control.
* [`src/main/java/com/heimdallauth/server/controllers/v1/management/ConfigurationSetManagementController.java`](diffhunk://#diff-fc569c26f68093b98d702d39090f4ee1b893025d9d50e3cbe18f1ca1dd1eb885R25-R36): Added `@PreAuthorize` annotations to the `getConfigurationSet`, `createNewConfigurationSet`, and `getConfigurationSetForTenantId` methods to restrict access to users with `ROLE_MANAGEMENT_READ` or `ROLE_MANAGEMENT_WRITE` roles.