### PR TITLE
HAS-39 Fix Configuration Set Management API security context

### DIFF
--- a/src/main/java/com/heimdallauth/server/controllers/v1/management/ConfigurationSetManagementController.java
+++ b/src/main/java/com/heimdallauth/server/controllers/v1/management/ConfigurationSetManagementController.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.UUID;
 
 @RestController
-@RequestMapping("/v1/management/configuration-set")
+@RequestMapping("/api/v1/management/configuration-set")
 @Tag(name = "Configuration Set Management Controller", description = "Controller for managing configuration sets")
 public class ConfigurationSetManagementController {
     private final ConfigurationSetManagementService configurationSetManagementService;


### PR DESCRIPTION
This pull request includes a change to the `ConfigurationSetManagementController` to update the base URL for the controller's endpoints.

* [`src/main/java/com/heimdallauth/server/controllers/v1/management/ConfigurationSetManagementController.java`](diffhunk://#diff-fc569c26f68093b98d702d39090f4ee1b893025d9d50e3cbe18f1ca1dd1eb885L16-R16): Changed the `@RequestMapping` annotation to update the base URL from `/v1/management/configuration-set` to `/api/v1/management/configuration-set`.