### PR TITLE
HAS-39 Fix an issue as the TenantID was not stored properly in the MongoDB

### DIFF
--- a/src/main/java/com/heimdallauth/server/documents/ConfigurationSetMasterDocument.java
+++ b/src/main/java/com/heimdallauth/server/documents/ConfigurationSetMasterDocument.java
@@ -22,7 +22,7 @@ public class ConfigurationSetMasterDocument {
     private String configurationSetName;
     private String configurationSetDescription;
     @Indexed
-    private UUID tenantId;
+    private String tenantId;
     @Indexed
     private List<String> suppressionListIds;
     private Instant createdAt;

--- a/src/main/java/com/heimdallauth/server/services/mongo/ConfigurationServiceManagementServiceMongoImpl.java
+++ b/src/main/java/com/heimdallauth/server/services/mongo/ConfigurationServiceManagementServiceMongoImpl.java
@@ -71,7 +71,7 @@ public class ConfigurationServiceManagementServiceMongoImpl implements Configura
         UUID configurationSetId = UUID.randomUUID();
         ConfigurationSetMasterDocument configurationSetMasterDocument = ConfigurationSetMasterDocument.builder()
                 .configurationId(configurationSetId.toString())
-                .tenantId(tenantId)
+                .tenantId(tenantId.toString())
                 .configurationSetName(createConfigurationSetPayload.configurationSetName())
                 .configurationSetDescription(createConfigurationSetPayload.configurationSetDescription())
                 .suppressionListIds(createConfigurationSetPayload.suppressionEntryIds().stream().map(UUID::toString).collect(Collectors.toList()))


### PR DESCRIPTION
This pull request includes changes to the `ConfigurationSetMasterDocument` and `ConfigurationServiceManagementServiceMongoImpl` classes to modify the data type of the `tenantId` field. The most important changes are:

* [`src/main/java/com/heimdallauth/server/documents/ConfigurationSetMasterDocument.java`](diffhunk://#diff-0ac1447f3c6bc029976843bccd4a8b2ca1bb7884326a2cfe900433900dc40c0eL25-R25): Changed the data type of the `tenantId` field from `UUID` to `String`.
* [`src/main/java/com/heimdallauth/server/services/mongo/ConfigurationServiceManagementServiceMongoImpl.java`](diffhunk://#diff-bcd03111769d7a27d1cd1b8d009049a1b0a3fe050e9f4cc10854e6e80295604bL74-R74): Updated the `tenantId` assignment to convert it to a string using the `toString()` method.