### PR TITLE
HAS-39 Update to fix the tenant id match when fetching all configuration set ids

### DIFF
--- a/src/main/java/com/heimdallauth/server/services/mongo/ConfigurationServiceManagementServiceMongoImpl.java
+++ b/src/main/java/com/heimdallauth/server/services/mongo/ConfigurationServiceManagementServiceMongoImpl.java
@@ -111,7 +111,7 @@ public class ConfigurationServiceManagementServiceMongoImpl implements Configura
 
     @Override
     public List<ConfigurationSetModel> getConfigurationSetsForTenantId(UUID tenantId) {
-        Query searchConfigurationSetForTenantQuery = Query.query(Criteria.where("tenantId").is(tenantId));
+        Query searchConfigurationSetForTenantQuery = Query.query(Criteria.where("tenantId").is(tenantId.toString()));
         List<ConfigurationSetMasterDocument> configurationSetDocuments = this.mongoTemplate.find(searchConfigurationSetForTenantQuery, ConfigurationSetMasterDocument.class, COLLECTION_CONFIGURATION_SETS);
         if(configurationSetDocuments.isEmpty()){
             return List.of();


### PR DESCRIPTION
This pull request includes a change to the `getConfigurationSetsForTenantId` method in the `ConfigurationServiceManagementServiceMongoImpl` class. The change ensures that the `tenantId` is converted to a string before being used in the query.

* [`src/main/java/com/heimdallauth/server/services/mongo/ConfigurationServiceManagementServiceMongoImpl.java`](diffhunk://#diff-bcd03111769d7a27d1cd1b8d009049a1b0a3fe050e9f4cc10854e6e80295604bL114-R114): Modified the `searchConfigurationSetForTenantQuery` to convert `tenantId` to a string.