### PR TITLE
HAS-45 Update to the ConfigurationMapper to properly map ConfiguraionID

### DIFF
--- a/src/main/java/com/heimdallauth/server/utils/mapper/ConfigurationMapper.java
+++ b/src/main/java/com/heimdallauth/server/utils/mapper/ConfigurationMapper.java
@@ -12,5 +12,6 @@ public interface ConfigurationMapper {
 
     @Mapping(source = "configurationId", target = "configurationSetId")
     ConfigurationSetModel toConfigurationSetModel(ConfigurationSetAggregationModel aggregationModel);
+    @Mapping(source = "configurationId", target = "configurationSetId")
     ConfigurationSetModel toConfigurationSetModel(ConfigurationSetMasterDocument masterDocument);
 }


### PR DESCRIPTION
This pull request includes a change to the `ConfigurationMapper` interface in the `src/main/java/com/heimdallauth/server/utils/mapper/ConfigurationMapper.java` file. The change adds a new method to map `ConfigurationSetMasterDocument` to `ConfigurationSetModel`.

* [`src/main/java/com/heimdallauth/server/utils/mapper/ConfigurationMapper.java`](diffhunk://#diff-02e9f71e7d1fa23de6ce43c746ae36016342eca05eb944432dc8be2c0d5919bdR15): Added a new mapping method to convert `ConfigurationSetMasterDocument` to `ConfigurationSetModel`.