### PR TITLE
HAS-39 Updates to the Configuration API to add endpoint for deleting configuration set

### DIFF
--- a/src/main/java/com/heimdallauth/server/controllers/v1/management/ConfigurationSetManagementController.java
+++ b/src/main/java/com/heimdallauth/server/controllers/v1/management/ConfigurationSetManagementController.java
@@ -43,4 +43,9 @@ public class ConfigurationSetManagementController {
         this.configurationSetManagementService.deleteConfigurationSetById(configurationSetId);
         return ResponseEntity.ok().build();
     }
+    @PutMapping("/{configurationSetId}/status")
+    @PreAuthorize("hasRole(@heimdallBifrostRoleConfiguration.ROLE_MANAGEMENT_WRITE)")
+    public ResponseEntity<ConfigurationSetModel> updateConfigurationSetStatus(@PathVariable("configurationSetId") UUID configurationSetId, @RequestParam("isEnabled") boolean isEnabled){
+        return ResponseEntity.ok(this.configurationSetManagementService.updateConfigurationSetStatus(configurationSetId, isEnabled));
+    }
 }

--- a/src/main/java/com/heimdallauth/server/controllers/v1/management/ConfigurationSetManagementController.java
+++ b/src/main/java/com/heimdallauth/server/controllers/v1/management/ConfigurationSetManagementController.java
@@ -37,4 +37,10 @@ public class ConfigurationSetManagementController {
     public ResponseEntity<List<ConfigurationSetModel>> getConfigurationSetForTenantId(@RequestParam("tenantId") UUID tenantId){
         return ResponseEntity.ok(this.configurationSetManagementService.getConfigurationSetsForTenantId(tenantId));
     }
+    @DeleteMapping("/{configurationSetId}")
+    @PreAuthorize("hasRole(@heimdallBifrostRoleConfiguration.ROLE_MANAGEMENT_WRITE)")
+    public ResponseEntity<Void> deleteConfigurationSetById(@PathVariable("configurationSetId") UUID configurationSetId){
+        this.configurationSetManagementService.deleteConfigurationSetById(configurationSetId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/heimdallauth/server/documents/ConfigurationSetMasterDocument.java
+++ b/src/main/java/com/heimdallauth/server/documents/ConfigurationSetMasterDocument.java
@@ -20,6 +20,7 @@ public class ConfigurationSetMasterDocument {
     @Id
     private String configurationId;
     private String configurationSetName;
+    private boolean isEnabled;
     private String configurationSetDescription;
     @Indexed
     private String tenantId;

--- a/src/main/java/com/heimdallauth/server/services/ConfigurationSetManagementService.java
+++ b/src/main/java/com/heimdallauth/server/services/ConfigurationSetManagementService.java
@@ -11,6 +11,7 @@ import java.util.UUID;
 public interface ConfigurationSetManagementService {
     ConfigurationSetModel createNewConfigurationSet(CreateConfigurationSetDTO createConfigurationSetPayload, UUID tenantID, boolean force) throws ConfigurationSetAlreadyExists;
     ConfigurationSetModel getConfigurationSetById(UUID configurationSetId) throws ConfigurationSetNotFound;
+    ConfigurationSetModel updateConfigurationSetStatus(UUID configurationSetId, boolean isEnabled) throws ConfigurationSetNotFound;
     List<ConfigurationSetModel> getConfigurationSetsForTenantId(UUID tenantId);
     void deleteConfigurationSetById(UUID configurationSetId);
     ConfigurationSetModel getConfigurationSetByNameAndTenantId(String configurationSetName, String tenantId) throws ConfigurationSetNotFound;

--- a/src/main/java/com/heimdallauth/server/services/ConfigurationSetManagementService.java
+++ b/src/main/java/com/heimdallauth/server/services/ConfigurationSetManagementService.java
@@ -12,6 +12,7 @@ public interface ConfigurationSetManagementService {
     ConfigurationSetModel createNewConfigurationSet(CreateConfigurationSetDTO createConfigurationSetPayload, UUID tenantID, boolean force) throws ConfigurationSetAlreadyExists;
     ConfigurationSetModel getConfigurationSetById(UUID configurationSetId) throws ConfigurationSetNotFound;
     List<ConfigurationSetModel> getConfigurationSetsForTenantId(UUID tenantId);
+    void deleteConfigurationSetById(UUID configurationSetId);
     ConfigurationSetModel getConfigurationSetByNameAndTenantId(String configurationSetName, String tenantId) throws ConfigurationSetNotFound;
     ConfigurationSetModel updateConfigurationSetMasterData(String configurationSetId, String configurationSetName, String configurationSetDescription) throws ConfigurationSetNotFound;
 }

--- a/src/main/java/com/heimdallauth/server/services/mongo/ConfigurationServiceManagementServiceMongoImpl.java
+++ b/src/main/java/com/heimdallauth/server/services/mongo/ConfigurationServiceManagementServiceMongoImpl.java
@@ -124,7 +124,11 @@ public class ConfigurationServiceManagementServiceMongoImpl implements Configura
     public void deleteConfigurationSetById(UUID configurationSetId) {
         Query deleteConfigurationSetQuery = Query.query(Criteria.where("_id").is(configurationSetId.toString()));
         DeleteResult deleteResult = this.mongoTemplate.remove(deleteConfigurationSetQuery, COLLECTION_CONFIGURATION_SETS);
-        log.debug("Deleted configuration set with ID: {}. Deleted count: {}", configurationSetId, deleteResult.getDeletedCount());
+        if(deleteResult.getDeletedCount() > 0){
+            log.debug("Deleted configuration set with ID: {}. Deleted count: {}", configurationSetId, deleteResult.getDeletedCount());
+        }else{
+            log.error("No instances matched, Nothing to delete. Deleted count: {}", 0);
+        }
     }
 
     /**

--- a/src/main/java/com/heimdallauth/server/services/mongo/ConfigurationServiceManagementServiceMongoImpl.java
+++ b/src/main/java/com/heimdallauth/server/services/mongo/ConfigurationServiceManagementServiceMongoImpl.java
@@ -120,6 +120,13 @@ public class ConfigurationServiceManagementServiceMongoImpl implements Configura
         }
     }
 
+    @Override
+    public void deleteConfigurationSetById(UUID configurationSetId) {
+        Query deleteConfigurationSetQuery = Query.query(Criteria.where("id").is(configurationSetId.toString()));
+        DeleteResult deleteResult = this.mongoTemplate.remove(deleteConfigurationSetQuery, COLLECTION_CONFIGURATION_SETS);
+        log.debug("Deleted configuration set with ID: {}. Deleted count: {}", configurationSetId, deleteResult.getDeletedCount());
+    }
+
     /**
      * Get a configuration set by its ID.
      *

--- a/src/main/java/com/heimdallauth/server/services/mongo/ConfigurationServiceManagementServiceMongoImpl.java
+++ b/src/main/java/com/heimdallauth/server/services/mongo/ConfigurationServiceManagementServiceMongoImpl.java
@@ -111,6 +111,14 @@ public class ConfigurationServiceManagementServiceMongoImpl implements Configura
         return null;
     }
 
+    /**
+     * Update the status of a configuration set.
+     *
+     * @param configurationSetId The ID of the configuration set to update.
+     * @param isEnabled The new status to set for the configuration set.
+     * @return The updated ConfigurationSetModel.
+     * @throws ConfigurationSetNotFound If no configuration set is found for the given ID.
+     */
     @Override
     public ConfigurationSetModel updateConfigurationSetStatus(UUID configurationSetId, boolean isEnabled) throws ConfigurationSetNotFound {
         Query configurationSetSearchQuery = Query.query(Criteria.where("_id").is(configurationSetId.toString()));
@@ -128,6 +136,12 @@ public class ConfigurationServiceManagementServiceMongoImpl implements Configura
         return null;
     }
 
+    /**
+     * Get all configuration sets for a given tenant ID.
+     *
+     * @param tenantId The ID of the tenant to retrieve configuration sets for.
+     * @return A list of ConfigurationSetModel objects associated with the given tenant ID.
+     */
     @Override
     public List<ConfigurationSetModel> getConfigurationSetsForTenantId(UUID tenantId) {
         Query searchConfigurationSetForTenantQuery = Query.query(Criteria.where("tenantId").is(tenantId.toString()));
@@ -139,6 +153,11 @@ public class ConfigurationServiceManagementServiceMongoImpl implements Configura
         }
     }
 
+    /**
+     * Delete a configuration set by its ID.
+     *
+     * @param configurationSetId The ID of the configuration set to delete.
+     */
     @Override
     public void deleteConfigurationSetById(UUID configurationSetId) {
         Query deleteConfigurationSetQuery = Query.query(Criteria.where("_id").is(configurationSetId.toString()));
@@ -210,6 +229,11 @@ public class ConfigurationServiceManagementServiceMongoImpl implements Configura
         }
     }
 
+    /**
+     * Get all suppression entries.
+     *
+     * @return A list of SuppressionEntryModel objects representing all suppression entries.
+     */
     @Override
     public List<SuppressionEntryModel> getAllSuppressionEntries() {
         List<SuppressionEntryDocument> allEntriesDocuments  = this.mongoTemplate.findAll(SuppressionEntryDocument.class, COLLECTION_SUPPRESSION_LIST);

--- a/src/main/java/com/heimdallauth/server/services/mongo/ConfigurationServiceManagementServiceMongoImpl.java
+++ b/src/main/java/com/heimdallauth/server/services/mongo/ConfigurationServiceManagementServiceMongoImpl.java
@@ -72,6 +72,7 @@ public class ConfigurationServiceManagementServiceMongoImpl implements Configura
         ConfigurationSetMasterDocument configurationSetMasterDocument = ConfigurationSetMasterDocument.builder()
                 .configurationId(configurationSetId.toString())
                 .tenantId(tenantId.toString())
+                .isEnabled(false)
                 .configurationSetName(createConfigurationSetPayload.configurationSetName())
                 .configurationSetDescription(createConfigurationSetPayload.configurationSetDescription())
                 .suppressionListIds(createConfigurationSetPayload.suppressionEntryIds().stream().map(UUID::toString).collect(Collectors.toList()))

--- a/src/main/java/com/heimdallauth/server/services/mongo/ConfigurationServiceManagementServiceMongoImpl.java
+++ b/src/main/java/com/heimdallauth/server/services/mongo/ConfigurationServiceManagementServiceMongoImpl.java
@@ -122,7 +122,7 @@ public class ConfigurationServiceManagementServiceMongoImpl implements Configura
 
     @Override
     public void deleteConfigurationSetById(UUID configurationSetId) {
-        Query deleteConfigurationSetQuery = Query.query(Criteria.where("id").is(configurationSetId.toString()));
+        Query deleteConfigurationSetQuery = Query.query(Criteria.where("_id").is(configurationSetId.toString()));
         DeleteResult deleteResult = this.mongoTemplate.remove(deleteConfigurationSetQuery, COLLECTION_CONFIGURATION_SETS);
         log.debug("Deleted configuration set with ID: {}. Deleted count: {}", configurationSetId, deleteResult.getDeletedCount());
     }

--- a/src/main/java/com/heimdallauth/server/services/mongo/ConfigurationServiceManagementServiceMongoImpl.java
+++ b/src/main/java/com/heimdallauth/server/services/mongo/ConfigurationServiceManagementServiceMongoImpl.java
@@ -120,7 +120,7 @@ public class ConfigurationServiceManagementServiceMongoImpl implements Configura
             throw new ConfigurationSetNotFound("Multiple configuration sets found with the same ID");
         }
         Update updateSpec = Update.update("isEnabled", isEnabled);
-        UpdateResult result = this.mongoTemplate.updateMulti(configurationSetSearchQuery, updateSpec, ConfigurationSetMasterDocument.class);
+        UpdateResult result = this.mongoTemplate.updateMulti(configurationSetSearchQuery, updateSpec, ConfigurationSetMasterDocument.class, COLLECTION_CONFIGURATION_SETS);
         if (result.getModifiedCount() > 0) {
             log.debug("Updated configuration set with ID: {}. Updated count: {}", configurationSetId, result.getModifiedCount());
             return this.getConfigurationSetById(configurationSetId);


### PR DESCRIPTION
This pull request adds functionality to delete a configuration set by its ID in the `ConfigurationSetManagementController`. The main changes include the addition of a new endpoint in the controller, updating the service interface, and implementing the delete method in the service implementation.

Key changes:

### Controller Changes:
* [`src/main/java/com/heimdallauth/server/controllers/v1/management/ConfigurationSetManagementController.java`](diffhunk://#diff-fc569c26f68093b98d702d39090f4ee1b893025d9d50e3cbe18f1ca1dd1eb885R40-R45): Added a new `@DeleteMapping` endpoint to handle deletion of configuration sets by their ID. This endpoint is secured with a `@PreAuthorize` annotation to ensure only users with the appropriate role can access it.

### Service Interface Changes:
* [`src/main/java/com/heimdallauth/server/services/ConfigurationSetManagementService.java`](diffhunk://#diff-f25696d97c6193ba80ffb648f73ee3ab6429b5a88401d9158b763103645164c9R15): Added a new method `deleteConfigurationSetById(UUID configurationSetId)` to the service interface to support the deletion functionality.

### Service Implementation Changes:
* [`src/main/java/com/heimdallauth/server/services/mongo/ConfigurationServiceManagementServiceMongoImpl.java`](diffhunk://#diff-bcd03111769d7a27d1cd1b8d009049a1b0a3fe050e9f4cc10854e6e80295604bR123-R133): Implemented the `deleteConfigurationSetById` method to perform the deletion operation in the MongoDB database. The method logs the result of the deletion operation.