### PR TITLE
HAS-39 Update to the OpenAPI Documentation to allow for Authentication

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ repositories {
 ext {
     set('springCloudVersion', "2024.0.0")
     set('handlebarsVersion', '4.4.0')
-    set('heimdallCommonsVersion','1.0.1')
+    set('heimdallCommonsVersion','38')
     set('mapStructVersion', '1.6.3')
 }
 

--- a/src/main/java/com/heimdallauth/server/configuration/OpenAPIConfig.java
+++ b/src/main/java/com/heimdallauth/server/configuration/OpenAPIConfig.java
@@ -14,11 +14,9 @@ import org.springframework.context.annotation.Configuration;
         type = SecuritySchemeType.OAUTH2,
         flows = @OAuthFlows(
                 clientCredentials = @OAuthFlow(
-                        tokenUrl = "https://keycloak-prod.ap-west-1.heimdallauth.com/realms/Heimdall%20Authentication%20-%20DEV",
+                        tokenUrl = "https://keycloak-prod.ap-west-1.heimdallauth.com/realms/mayanksoni-tech-dev",
                         scopes = {
-                                @OAuthScope(name = "openid", description = "OpenID scope"),
-                                @OAuthScope(name = "profile", description = "Profile scope"),
-                                @OAuthScope(name = "email", description = "Email scope")
+                                @OAuthScope(name = "openid", description = "OpenID scope")
                         }
                 )
         )
@@ -35,16 +33,6 @@ import org.springframework.context.annotation.Configuration;
                 version = "1.0",
                 description = "API documentation for Heimdall Bifrost"
         ),
-        servers = {
-                @Server(
-                        url = "http://localhost:8080",
-                        description = "Local server"
-                ),
-                @Server(
-                        url = "https://heimdall-bifrost-dev.dev.ap-west-1.heimdallauth.com",
-                        description = "Development CD Server"
-                )
-        },
         security = {
                 @SecurityRequirement(
                         name = "oauth2",

--- a/src/main/java/com/heimdallauth/server/configuration/OpenAPIConfig.java
+++ b/src/main/java/com/heimdallauth/server/configuration/OpenAPIConfig.java
@@ -1,0 +1,59 @@
+package com.heimdallauth.server.configuration;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.*;
+import io.swagger.v3.oas.annotations.servers.Server;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@SecurityScheme(
+        name = "oauth2",
+        type = SecuritySchemeType.OAUTH2,
+        flows = @OAuthFlows(
+                clientCredentials = @OAuthFlow(
+                        tokenUrl = "https://keycloak-prod.ap-west-1.heimdallauth.com/realms/Heimdall%20Authentication%20-%20DEV",
+                        scopes = {
+                                @OAuthScope(name = "openid", description = "OpenID scope"),
+                                @OAuthScope(name = "profile", description = "Profile scope"),
+                                @OAuthScope(name = "email", description = "Email scope")
+                        }
+                )
+        )
+)
+@SecurityScheme(
+        name = "bearerAuth",
+        type = SecuritySchemeType.APIKEY,
+        in = SecuritySchemeIn.HEADER,
+        paramName = "Authorization"
+)
+@OpenAPIDefinition(
+        info = @Info(
+                title = "Heimdall Bifrost API",
+                version = "1.0",
+                description = "API documentation for Heimdall Bifrost"
+        ),
+        servers = {
+                @Server(
+                        url = "http://localhost:8080",
+                        description = "Local server"
+                ),
+                @Server(
+                        url = "https://heimdall-bifrost-dev.dev.ap-west-1.heimdallauth.com",
+                        description = "Development CD Server"
+                )
+        },
+        security = {
+                @SecurityRequirement(
+                        name = "oauth2",
+                        scopes = {"openid", "profile", "email"}
+                ),
+                @SecurityRequirement(
+                        name = "bearerAuth"
+                )
+        }
+)
+public class OpenAPIConfig {
+}


### PR DESCRIPTION
This pull request introduces a new configuration class for OpenAPI documentation in the `Heimdall Bifrost API`. The changes include setting up security schemes and defining API information and server details.

Configuration for OpenAPI documentation:

* [`src/main/java/com/heimdallauth/server/configuration/OpenAPIConfig.java`](diffhunk://#diff-ad97530a42732c21d04597b4403b71c895ad993b6fd2c6c821d83b0b020ebcfdR1-R59): Added a new configuration class `OpenAPIConfig` to define OpenAPI documentation settings, including security schemes for OAuth2 and API key, API information, and server details.