### PR TITLE
HAS-39 Update to properly map suppression entries in DTO

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ repositories {
 ext {
     set('springCloudVersion', "2024.0.0")
     set('handlebarsVersion', '4.4.0')
-    set('heimdallCommonsVersion','39')
+    set('heimdallCommonsVersion','40')
     set('mapStructVersion', '1.6.3')
 }
 

--- a/src/main/java/com/heimdallauth/server/utils/mapper/ConfigurationMapper.java
+++ b/src/main/java/com/heimdallauth/server/utils/mapper/ConfigurationMapper.java
@@ -6,10 +6,11 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingConstants;
 
-@Mapper(componentModel = MappingConstants.ComponentModel.SPRING, uses = {SmtpPropertiesMapper.class})
+@Mapper(componentModel = MappingConstants.ComponentModel.SPRING, uses = {SmtpPropertiesMapper.class, SuppressionEntryMapper.class})
 public interface ConfigurationMapper {
 
     @Mapping(source = "configurationId", target = "configurationSetId")
+    @Mapping(source = "aggregationModel.suppressionEntries", target = "suppressionEntries", qualifiedByName = "toSuppressionEntryModel")
     @Mapping(source = "aggregationModel.smtpProperties", target = "smtpProperties", qualifiedByName = "toSmtpProperties")
     ConfigurationSetModel toConfigurationSetModel(ConfigurationSetAggregationModel aggregationModel);
 }

--- a/src/main/java/com/heimdallauth/server/utils/mapper/SuppressionEntryMapper.java
+++ b/src/main/java/com/heimdallauth/server/utils/mapper/SuppressionEntryMapper.java
@@ -2,16 +2,14 @@ package com.heimdallauth.server.utils.mapper;
 
 import com.heimdallauth.server.documents.SuppressionEntryDocument;
 import com.heimdallauth.server.models.bifrost.SuppressionEntryModel;
-import org.mapstruct.InheritInverseConfiguration;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-import org.mapstruct.MappingConstants;
+import org.mapstruct.*;
 
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
 public interface SuppressionEntryMapper {
 
     @Mapping(source = "id", target = "suppressionEntryId")
     @Mapping(source = "entryType", target = "suppressionListEntryType")
+    @Named("toSuppressionEntryModel")
     SuppressionEntryModel map(SuppressionEntryDocument suppressionEntryDocument);
 
     @InheritInverseConfiguration


### PR DESCRIPTION
This pull request includes updates to the `ConfigurationMapper` and `SuppressionEntryMapper` to enhance the mapping functionality and ensure proper integration of suppression entries.

Enhancements to mapping functionality:

* [`src/main/java/com/heimdallauth/server/utils/mapper/ConfigurationMapper.java`](diffhunk://#diff-02e9f71e7d1fa23de6ce43c746ae36016342eca05eb944432dc8be2c0d5919bdL9-R13): Added `SuppressionEntryMapper` to the `@Mapper` annotation and mapped `aggregationModel.suppressionEntries` to `suppressionEntries` using the `toSuppressionEntryModel` method.
* [`src/main/java/com/heimdallauth/server/utils/mapper/SuppressionEntryMapper.java`](diffhunk://#diff-d3399fe57f243c2a35c5bf4dbda346fc931c16ab0aede3685f5e4274a18f254cL5-R12): Added the `@Named` annotation to the `map` method to allow it to be used as a qualified mapping method.