### PR TITLE
HAS-57 Updates to the SendEmailProcessor to remove code duplications

### DIFF
--- a/src/main/java/com/heimdallauth/server/services/JavaMailSenderFactory.java
+++ b/src/main/java/com/heimdallauth/server/services/JavaMailSenderFactory.java
@@ -100,7 +100,7 @@ public class JavaMailSenderFactory {
             return configureMailSenderFromDataSource(configurationId);
         });
     }
-    protected void evictCache(UUID configurationId) {
+    public void evictCache(UUID configurationId) {
         mailSenderCache.invalidate(configurationId.toString());
     }
 }

--- a/src/main/java/com/heimdallauth/server/services/SendEmailProcessor.java
+++ b/src/main/java/com/heimdallauth/server/services/SendEmailProcessor.java
@@ -13,7 +13,10 @@ import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 
 import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
 

--- a/src/main/java/com/heimdallauth/server/services/SendEmailProcessor.java
+++ b/src/main/java/com/heimdallauth/server/services/SendEmailProcessor.java
@@ -40,7 +40,7 @@ public class SendEmailProcessor {
             validateSendEmailPayload(sendEmailDTO);
             if(sendEmailDTO.content() != null){
                 log.debug("Sending Email using platform sender");
-                JavaMailSender platformJavaMailSender = javaMailSenderFactory.getMailSender(null);
+                JavaMailSender platformJavaMailSender = javaMailSenderFactory.getMailSender(Optional.empty());
                 this.prepareEmailPayload(
                         sendEmailDTO.destination(),
                         DEFAULT_FROM_ADDRESS,
@@ -57,7 +57,7 @@ public class SendEmailProcessor {
                         log.error("Tenant ID mismatch for Template ID: {} and ConfigurationSet ID: {}", sendEmailDTO.templateId(), sendEmailDTO.configurationSetId());
                         throw new HeimdallBifrostBadDataException("Template does not belong to the same tenant as the configuration set");
                     }
-                    this.prepareEmailPayload(sendEmailDTO.destination(),configurationSetModel.smtpProperties().fromEmailAddress(), fetchedTemplate.content(), sendEmailDTO.context(), javaMailSenderFactory.getMailSender(sendEmailDTO.configurationSetId()));
+                    this.prepareEmailPayload(sendEmailDTO.destination(),configurationSetModel.smtpProperties().fromEmailAddress(), fetchedTemplate.content(), sendEmailDTO.context(), javaMailSenderFactory.getMailSender(Optional.ofNullable(configurationSetModel.smtpProperties())));
                 }catch (TemplateNotFound e){
                     log.error("Template not found for ID: {}", sendEmailDTO.templateId());
                     throw new HeimdallBifrostBadDataException("Template not found", e);


### PR DESCRIPTION
This pull request includes several changes to the `SendEmailProcessor` class, focusing on refactoring and improving the email sending process. Additionally, there is a minor change in the `JavaMailSenderFactory` class to make a method public.

### Refactoring and improvements in `SendEmailProcessor`:

* Consolidated imports in `SendEmailProcessor` by using a wildcard import for the `bifrost` package.
* Removed the unused `ThreadLocal<ConfigurationSetModel>` field from `SendEmailProcessor`.
* Refactored the `processSendEmail` method to use the new `prepareEmailPayload` method for processing and sending emails, reducing code duplication. [[1]](diffhunk://#diff-b2f0189d1bb040a84d8acb7f9d0a9a671f3b63647bd9e060132a830570ae91dbL44-R50) [[2]](diffhunk://#diff-b2f0189d1bb040a84d8acb7f9d0a9a671f3b63647bd9e060132a830570ae91dbL74-R61)
* Added Javadoc comments for the `connectAndSendEmail`, `validateSendEmailPayload`, and `prepareEmailPayload` methods to improve code documentation. [[1]](diffhunk://#diff-b2f0189d1bb040a84d8acb7f9d0a9a671f3b63647bd9e060132a830570ae91dbR78-R88) [[2]](diffhunk://#diff-b2f0189d1bb040a84d8acb7f9d0a9a671f3b63647bd9e060132a830570ae91dbR104-R137)

### Minor change in `JavaMailSenderFactory`:

* Changed the visibility of the `evictCache` method from protected to public to allow external access.