### PR TITLE
HAS-56 Updates to the JavaMailSenderFactory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,8 +34,8 @@ repositories {
 ext {
     set('springCloudVersion', "2024.0.0")
     set('handlebarsVersion', '4.4.0')
-    set('heimdallCommonsVersion','2.0.1')
-//    set('heimdallCommonsVersion','55')
+    set('heimdallCommonsVersion','2.0.2')
+//    set('heimdallCommonsVersion','58')
     set('mapStructVersion', '1.6.3')
     set('caffeineCacheVersion','3.2.0')
 }

--- a/src/main/java/com/heimdallauth/server/services/JavaMailSenderFactory.java
+++ b/src/main/java/com/heimdallauth/server/services/JavaMailSenderFactory.java
@@ -3,8 +3,6 @@ package com.heimdallauth.server.services;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.heimdallauth.server.constants.bifrost.SmtpAuthenticationMethod;
-import com.heimdallauth.server.exceptions.ConfigurationSetNotFound;
-import com.heimdallauth.server.models.bifrost.ConfigurationSetModel;
 import com.heimdallauth.server.models.bifrost.SmtpProperties;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -20,11 +18,9 @@ import java.util.concurrent.TimeUnit;
 @Slf4j
 public class JavaMailSenderFactory {
     private final JavaMailSender platformJavaMailSender;
-    private final ConfigurationSetManagementService configurationSetManagementService;
     private final Cache<String, JavaMailSender> mailSenderCache;
 
-    public JavaMailSenderFactory(JavaMailSender platformJavaMailSender, ConfigurationSetManagementService configurationSetManagementService) {
-        this.configurationSetManagementService = configurationSetManagementService;
+    public JavaMailSenderFactory(JavaMailSender platformJavaMailSender) {
         this.platformJavaMailSender = platformJavaMailSender;
         this.mailSenderCache = Caffeine.newBuilder().expireAfterWrite(5,TimeUnit.HOURS).maximumSize(1000).build();
     }
@@ -37,6 +33,7 @@ public class JavaMailSenderFactory {
      * @return A configured JavaMailSender instance.
      */
     private JavaMailSender getJavaMailSender(SmtpProperties smtpProperties) {
+        log.debug("Creating new instance of JavaMailSender for smtpProperties: {}", smtpProperties.propertiesId());
         JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
         javaMailSender.setHost(smtpProperties.serverAddress());
         javaMailSender.setPort(smtpProperties.portNumber());
@@ -57,49 +54,20 @@ public class JavaMailSenderFactory {
     }
 
     /**
-     * This method configures a JavaMailSender instance based on the provided configurationId.
-     * It retrieves the SmtpProperties from the ConfigurationSetModel and creates a JavaMailSender.
-     * If the configurationId is not found, it returns the default platform mail sender.
+     * This method retrieves the JavaMailSender instance from cache or creates a new one if it doesn't exist.
      *
-     * @param configurationId The UUID of the configuration set.
+     * @param smtpProperties The SmtpProperties from the configuration set
      * @return A configured JavaMailSender instance.
      */
-    private JavaMailSender configureMailSenderFromDataSource(UUID configurationId){
-        log.debug("Configuring JavaMailSender from DataSource");
-        try{
-            Optional<ConfigurationSetModel> configurationSetModel = Optional.ofNullable(this.configurationSetManagementService.getConfigurationSetById(configurationId));
-            if(configurationSetModel.isPresent()){
-                SmtpProperties smtpProperties = configurationSetModel.get().smtpProperties();
-                if(smtpProperties == null) {
-                    log.debug("SMTP Properties not found. Using default platform mail sender");
-                    return platformJavaMailSender;
-                }
-                return getJavaMailSender(smtpProperties);
-            }
-        }catch (ConfigurationSetNotFound ex){
-            log.debug("SMTP Properties not found. Using default platform mail sender");
+    public JavaMailSender getMailSender(Optional<SmtpProperties> smtpProperties) {
+        if(smtpProperties.isEmpty()) {
+            log.debug("No smtpProperties found, returning platform returning platform JavaMailSender");
             return platformJavaMailSender;
+        }else{
+            return mailSenderCache.get(smtpProperties.get().propertiesId(), key -> getJavaMailSender(smtpProperties.get()));
         }
-        return null; //Unreachable Code
     }
-    /**
-     * This method retrieves a JavaMailSender instance based on the provided configurationId.
-     * It checks if the JavaMailSender is already present in the cache map. If not, it configures
-     * a new JavaMailSender using the configurationId and returns it.
-     *
-     * @param configurationId The UUID of the configuration set.
-     * @return A configured JavaMailSender instance.
-     */
-    public JavaMailSender getMailSender(UUID configurationId) {
-        if(configurationId == null) {
-            log.debug("Configuration ID is null. Using default platform mail sender");
-            return platformJavaMailSender;
-        }
-        return mailSenderCache.get(configurationId.toString(), key -> {
-            log.debug("JavaMailSender not found in cache. Configuring a new one.");
-            return configureMailSenderFromDataSource(configurationId);
-        });
-    }
+
     protected void evictCache(UUID configurationId) {
         mailSenderCache.invalidate(configurationId.toString());
     }

--- a/src/main/java/com/heimdallauth/server/utils/mapper/SmtpPropertiesMapper.java
+++ b/src/main/java/com/heimdallauth/server/utils/mapper/SmtpPropertiesMapper.java
@@ -15,6 +15,7 @@ public interface SmtpPropertiesMapper {
     @Mapping(source = "smtpServerLoginUsername", target = "loginUsername")
     @Mapping(source = "smtpServerLoginPassword", target = "loginPassword")
     @Mapping(source = "fromEmailAddress", target = "fromEmailAddress")
+    @Mapping(source = "id", target = "propertiesId")
     @Named("toSmtpProperties")
     SmtpProperties toSmtpProperties(SmtpPropertiesDocument smtpPropertiesDocument);
 }


### PR DESCRIPTION
This pull request includes significant changes to the `JavaMailSenderFactory` and related classes to simplify the email sending process and improve code maintainability. The most important changes are the removal of the `ConfigurationSetManagementService` dependency and the refactoring of methods to use `Optional<SmtpProperties>` instead of configuration IDs.

Simplification of `JavaMailSenderFactory`:

* Removed the `ConfigurationSetManagementService` dependency and related methods from `JavaMailSenderFactory` to streamline the class. [[1]](diffhunk://#diff-0f08d75c763c52b7e921c9e7fd0421cff3290d87ecb7231b3c9ec7a1418ef7aaL23-R23) [[2]](diffhunk://#diff-0f08d75c763c52b7e921c9e7fd0421cff3290d87ecb7231b3c9ec7a1418ef7aaL60-R70)
* Refactored the `getMailSender` method to use `Optional<SmtpProperties>` instead of configuration IDs, simplifying the retrieval and creation of `JavaMailSender` instances.

Refactoring in `SendEmailProcessor`:

* Updated the `processSendEmail` method to use `Optional.empty()` for the platform mail sender and `Optional.ofNullable` for tenant-specific mail senders. [[1]](diffhunk://#diff-b2f0189d1bb040a84d8acb7f9d0a9a671f3b63647bd9e060132a830570ae91dbL56-R54) [[2]](diffhunk://#diff-b2f0189d1bb040a84d8acb7f9d0a9a671f3b63647bd9e060132a830570ae91dbL70-R76)

Logging and utility improvements:

* Added a debug log statement in `getJavaMailSender` to log the creation of new `JavaMailSender` instances.
* Included a new mapping in `SmtpPropertiesMapper` to map the `id` field to `propertiesId` in `SmtpProperties`.