### PR TITLE
Updated the MailController API Security

### DIFF
--- a/src/main/java/com/heimdallauth/server/configuration/HeimdallBifrostRoleConfiguration.java
+++ b/src/main/java/com/heimdallauth/server/configuration/HeimdallBifrostRoleConfiguration.java
@@ -31,6 +31,7 @@ public class HeimdallBifrostRoleConfiguration {
     private String ROLE_MANAGEMENT_SMTP_WRITE;
     // Send Email Role
     private String ROLE_SEND_EMAIL;
+    private String SCOPE_SEND_EMAIL;
     //Management API Scope
     private String SCOPE_MANAGEMENT_READ;
     private String SCOPE_MANAGEMENT_WRITE;

--- a/src/main/java/com/heimdallauth/server/configuration/WebSecurityConfiguration.java
+++ b/src/main/java/com/heimdallauth/server/configuration/WebSecurityConfiguration.java
@@ -7,8 +7,11 @@ import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 
 @Configuration
 @EnableWebSecurity
@@ -29,9 +32,11 @@ public class WebSecurityConfiguration {
                         authz.requestMatchers("/actuator/**").permitAll()
                                 .requestMatchers("/swagger-ui/**").permitAll()
                                 .requestMatchers("/v3/api-docs/**").permitAll()
-                                .requestMatchers("/v1/management/**").hasRole("SUPERDUPERADMIN")
                                 .anyRequest().authenticated()
-                ).csrf(Customizer.withDefaults())
+                )
+                .csrf(csrf -> {
+                    csrf.ignoringRequestMatchers("/api/**", "/actuator/**");
+                })
                 .oauth2ResourceServer(oauth2 -> oauth2
                         .jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter))
                 );

--- a/src/main/java/com/heimdallauth/server/controllers/v1/management/MailController.java
+++ b/src/main/java/com/heimdallauth/server/controllers/v1/management/MailController.java
@@ -22,7 +22,7 @@ public class MailController {
     }
 
     @PostMapping("/send")
-    @PreAuthorize("hasRole(@heimdallBifrostRoleConfiguration.ROLE_SEND_EMAIL) or hasAuthority(@heimdallBifrostRoleConfiguration.SCOPE_SEND_EMAIL)")
+    @PreAuthorize("hasAuthority(@heimdallBifrostRoleConfiguration.SCOPE_SEND_EMAIL)")
     public ResponseEntity<Void> sendEmailWithConfiguration(@RequestBody SendEmailDTO sendEmailDTO) {
         this.sendEmailProcessor.processSendEmail(sendEmailDTO);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/heimdallauth/server/controllers/v1/management/MailController.java
+++ b/src/main/java/com/heimdallauth/server/controllers/v1/management/MailController.java
@@ -2,6 +2,7 @@ package com.heimdallauth.server.controllers.v1.management;
 
 import com.heimdallauth.server.dto.bifrost.SendEmailDTO;
 import com.heimdallauth.server.services.SendEmailProcessor;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.mail.MessagingException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/email")
+@Tag(name = "Email API", description = "Email API for sending emails")
 public class MailController {
     private final SendEmailProcessor sendEmailProcessor;
 
@@ -20,8 +22,8 @@ public class MailController {
     }
 
     @PostMapping("/send")
-    @PreAuthorize("hasRole(@heimdallBifrostRoleConfiguration.ROLE_SEND_EMAIL)")
-    public ResponseEntity<Void> sendEmailWithConfiguration(@RequestBody SendEmailDTO sendEmailDTO) throws MessagingException {
+    @PreAuthorize("hasRole(@heimdallBifrostRoleConfiguration.ROLE_SEND_EMAIL) or hasAuthority(@heimdallBifrostRoleConfiguration.SCOPE_SEND_EMAIL)")
+    public ResponseEntity<Void> sendEmailWithConfiguration(@RequestBody SendEmailDTO sendEmailDTO) {
         this.sendEmailProcessor.processSendEmail(sendEmailDTO);
         return ResponseEntity.ok().build();
     }

--- a/src/main/resources/application-develop.yml
+++ b/src/main/resources/application-develop.yml
@@ -33,6 +33,7 @@ heimdall:
           role-management-email-template-write-tenant: WRITE:MANAGEMENT:EMAIL-TEMPLATE:TENANT
           role-management-email-template-read: READ:MANAGEMENT:EMAIL-TEMPLATE
           role-management-email-template-write: WRITE:MANAGEMENT:EMAIL-TEMPLATE
+          scope-send-email: SEND:EMAIL
         client:
           client-id: ${OAUTH_CLIENT_ID}
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -34,10 +34,11 @@ heimdall:
           role-management-email-template-read: READ:MANAGEMENT:EMAIL-TEMPLATE
           role-management-email-template-write: WRITE:MANAGEMENT:EMAIL-TEMPLATE
           role-send-email: SEND:EMAIL
+          scope-send-email: SEND:EMAIL
         client:
           client-id: ${OAUTH_CLIENT_ID}
 
 logging:
   level:
-    org.springframework.security: INFO
+    org.springframework.security: DEBUG
     com.heimdallauth.server.services: DEBUG

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -40,5 +40,5 @@ heimdall:
 
 logging:
   level:
-    org.springframework.security: DEBUG
+    org.springframework.security: TRACE
     com.heimdallauth.server.services: DEBUG


### PR DESCRIPTION
This pull request includes several changes to the security configuration and email handling in the HeimdallAuth server. The most important changes are the addition of a new scope for sending emails, updates to the CSRF configuration, and adjustments to the `MailController` to use the new scope.

Security configuration updates:

* [`src/main/java/com/heimdallauth/server/configuration/WebSecurityConfiguration.java`](diffhunk://#diff-381520e9783ebad1ee587b19a458676b43630e2775939e7f01961b2225346514R10-R14): Added `AbstractHttpConfigurer`, `CookieCsrfTokenRepository`, and `CsrfTokenRequestAttributeHandler` imports. Updated CSRF configuration to ignore certain request matchers. [[1]](diffhunk://#diff-381520e9783ebad1ee587b19a458676b43630e2775939e7f01961b2225346514R10-R14) [[2]](diffhunk://#diff-381520e9783ebad1ee587b19a458676b43630e2775939e7f01961b2225346514L32-R39)

Email handling updates:

* [`src/main/java/com/heimdallauth/server/configuration/HeimdallBifrostRoleConfiguration.java`](diffhunk://#diff-4dc731462e8f3ac5711dbd8855b1ef9e94838d0807bb991ffea6625c76e39fc7R34): Added `SCOPE_SEND_EMAIL` field.
* [`src/main/java/com/heimdallauth/server/controllers/v1/management/MailController.java`](diffhunk://#diff-ffa470e02af52fff918786887bf0ac4bd4f8064c685cc8eb8b52d880c4748038R5): Added `@Tag` annotation for Swagger documentation. Changed `sendEmailWithConfiguration` method to use `SCOPE_SEND_EMAIL` instead of `ROLE_SEND_EMAIL`. [[1]](diffhunk://#diff-ffa470e02af52fff918786887bf0ac4bd4f8064c685cc8eb8b52d880c4748038R5) [[2]](diffhunk://#diff-ffa470e02af52fff918786887bf0ac4bd4f8064c685cc8eb8b52d880c4748038R16) [[3]](diffhunk://#diff-ffa470e02af52fff918786887bf0ac4bd4f8064c685cc8eb8b52d880c4748038L23-R26)

Configuration file updates:

* [`src/main/resources/application-develop.yml`](diffhunk://#diff-7d8e1ef91f16013125ecc70848d2bf2ff80cf92da790e50c1fcbd850cd62eb5dR36): Added `scope-send-email` configuration.
* [`src/main/resources/application-local.yml`](diffhunk://#diff-43a78ff616f196d58ca4ff339d581c4c183d5872bf6b85a877a4bc14f7c240c1R37-R43): Added `scope-send-email` configuration and changed logging level for `org.springframework.security` to `TRACE`.